### PR TITLE
Correction au lien mailto:

### DIFF
--- a/enseignant.md
+++ b/enseignant.md
@@ -6,7 +6,7 @@
 |---|---|
 | Nom | [Jean-Hugues Roy](http://jhroy.ca "Mon blogue perso que je vous invite à consulter pour des exemples de journalisme informatique") 
 | Bureau | J-4185 |
-| Courriel | [roy.jean-hugues@uqam.ca](/mailto:roy.jean-hugues@uqam.ca) |
+| Courriel | [roy.jean-hugues@uqam.ca](mailto:roy.jean-hugues@uqam.ca) |
 | Tél. | 514/987-3000, 6102 |
 | Mobile/Signal | 514/778-6102 |
 | Twitter | [@jeanhuguesroy](https://twitter.com/jeanhuguesroy) |


### PR DESCRIPTION
Le préfixe `/` pourrait nuire à la génération du lien, voir par exemple sur <https://github.com/jhroy/syllabus-EDM5240-H2019/blob/3004603bc8fe94f418700b034ad8701c22845bef/enseignant.md>